### PR TITLE
Remove unused variables from env

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv'
-import { cleanEnv, host, num, port, str, testOnly } from 'envalid'
+import { cleanEnv, host, port, str, testOnly } from 'envalid'
 
 dotenv.config()
 
@@ -13,6 +13,4 @@ export const env = cleanEnv(process.env, {
   PUBLIC_URL: str({}),
   DB_PATH: str({ devDefault: ':memory:' }),
   COOKIE_SECRET: str({ devDefault: '00000000000000000000000000000000' }),
-  COMMON_RATE_LIMIT_MAX_REQUESTS: num({ devDefault: testOnly(1000) }),
-  COMMON_RATE_LIMIT_WINDOW_MS: num({ devDefault: testOnly(1000) }),
 })


### PR DESCRIPTION
Following the README, running `npm run dev` causes an error. Adding `COMMON_RATE_LIMIT_MAX_REQUESTS` and `COMMON_RATE_LIMIT_WINDOW_MS` to the .env file fixes it, but since they are not currently used, I have removed them instead.

```
$ npm run dev

> atproto-example-app@0.0.1 dev
> tsx watch --clear-screen=false src/index.ts | pino-pretty

/home/ubuntu/playground/statusphere-example-app/node_modules/envalid/src/core.ts:79
          throw new EnvMissingError(formatSpecDescription(spec))
                ^


EnvMissingError: undefined
    at getSanitizedEnv (/home/ubuntu/playground/statusphere-example-app/node_modules/envalid/src/core.ts:79:17)
    at cleanEnv (/home/ubuntu/playground/statusphere-example-app/node_modules/envalid/src/envalid.ts:18:34)
    at dotenv (/home/ubuntu/playground/statusphere-example-app/src/lib/env.ts:6:20)
    at Object.<anonymous> (/home/ubuntu/playground/statusphere-example-app/src/lib/env.ts:18:2)
    at Module._compile (node:internal/modules/cjs/loader:1504:14)
    at Object.transformer (/home/ubuntu/playground/statusphere-example-app/node_modules/tsx/dist/register-C1urN2EO.cjs:2:1122)
    at Module.load (node:internal/modules/cjs/loader:1282:32)
    at Module._load (node:internal/modules/cjs/loader:1098:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:215:24)

Node.js v22.5.1
```
