### PR TITLE
Allow insecure cookie handling in development mode

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -38,10 +38,7 @@ async function getSessionAgent(
   res: ServerResponse<IncomingMessage>,
   ctx: AppContext
 ) {
-  const session = await getIronSession<Session>(req, res, {
-    cookieName: 'sid',
-    password: env.COOKIE_SECRET,
-  })
+  const session = await getSession(req, res)
   if (!session.did) return null
   try {
     const oauthSession = await ctx.oauthClient.restore(session.did)
@@ -74,10 +71,7 @@ export const createRouter = (ctx: AppContext) => {
       const params = new URLSearchParams(req.originalUrl.split('?')[1])
       try {
         const { session } = await ctx.oauthClient.callback(params)
-        const clientSession = await getIronSession<Session>(req, res, {
-          cookieName: 'sid',
-          password: env.COOKIE_SECRET,
-        })
+        const clientSession = await getSession(req, res)
         assert(!clientSession.did, 'session already exists')
         clientSession.did = session.did
         await clientSession.save()
@@ -133,10 +127,7 @@ export const createRouter = (ctx: AppContext) => {
   router.post(
     '/logout',
     handler(async (req, res) => {
-      const session = await getIronSession<Session>(req, res, {
-        cookieName: 'sid',
-        password: env.COOKIE_SECRET,
-      })
+      const session = await getSession(req, res)
       await session.destroy()
       return res.redirect('/')
     })
@@ -274,4 +265,14 @@ export const createRouter = (ctx: AppContext) => {
   )
 
   return router
+}
+
+async function getSession(req: IncomingMessage, res: ServerResponse<IncomingMessage>) {
+  return await getIronSession<Session>(req, res, {
+    cookieName: 'sid',
+    password: env.COOKIE_SECRET,
+    cookieOptions: {
+      secure: env.NODE_ENV === 'production',
+    },
+  })
 }


### PR DESCRIPTION
Safari throws out insecure cookies over http, even on localhost.  This PR extracts calls to `getIronSession` to a small helper function to deduplicate some code, and adds the `cookieOptions` parameter to specify that the cookies only need to be secure when the app is running in production.

This is an extension of #23 