### PR TITLE
Update better-sqlite3 to latest minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@atproto/sync": "^0.1.4",
     "@atproto/syntax": "^0.3.0",
     "@atproto/xrpc-server": "^0.7.9",
-    "better-sqlite3": "^11.1.2",
+    "better-sqlite3": "^11.10.0",
     "dotenv": "^16.4.5",
     "envalid": "^8.0.0",
     "express": "^4.19.2",


### PR DESCRIPTION
For some reason, this older version of `better-sqlite3` was causing the same error that is outlined in this issue https://github.com/WiseLibs/better-sqlite3/issues/1267

Updating it to the latest doesn't appear to have affected the status application's behaviour but fixes the install error.