### PR TITLE
feat: show logged-in user handle if no displayName

### DIFF
--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -37,7 +37,8 @@ const STATUS_OPTIONS = [
 type Props = {
   statuses: Status[]
   didHandleMap: Record<string, string>
-  profile?: { displayName?: string }
+  profile?: { displayName?: string },
+  loggedInUserHandle?: string,
   myStatus?: Status
 }
 
@@ -48,7 +49,7 @@ export function home(props: Props) {
   })
 }
 
-function content({ statuses, didHandleMap, profile, myStatus }: Props) {
+function content({ statuses, didHandleMap, profile, loggedInUserHandle, myStatus }: Props) {
   return html`<div id="root">
     <div class="error"></div>
     <div id="header">
@@ -60,7 +61,7 @@ function content({ statuses, didHandleMap, profile, myStatus }: Props) {
         ${profile
           ? html`<form action="/logout" method="post" class="session-form">
               <div>
-                Hi, <strong>${profile.displayName || 'friend'}</strong>. What's
+                Hi, <strong>${profile.displayName || (loggedInUserHandle && `@${loggedInUserHandle}`) || 'friend'}</strong>. What's
                 your status today?
               </div>
               <div>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -181,6 +181,7 @@ export const createRouter = (ctx: AppContext) => {
         collection: 'app.bsky.actor.profile',
         rkey: 'self',
       }).catch(() => undefined);
+      const loggedInUserHandle = await ctx.resolver.resolveDidToHandle(agent.assertDid)
 
       const profileRecord = profileResponse?.data;
 
@@ -197,6 +198,7 @@ export const createRouter = (ctx: AppContext) => {
             statuses,
             didHandleMap,
             profile,
+            loggedInUserHandle,
             myStatus,
           })
         )


### PR DESCRIPTION
It was a bit confusing that I wasn't shown any self identifying info when I logged in at first. 

It was because I don't have a displayName set on my profile. 

This PR uses the resolved handle of the logged in user instead of 'friend' if they don't have a displayName set.

# Before
<img width="604" height="558" alt="image" src="https://github.com/user-attachments/assets/568bb503-3fc9-4f3a-8577-bef82d155d68" />

# After
<img width="658" height="488" alt="image" src="https://github.com/user-attachments/assets/1d4370d6-c70c-4a66-8148-9b885119697b" />
