### PR TITLE
Enable user registration via prompt=create

### DIFF
--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -62,5 +62,6 @@ export async function createOAuthClient(db: Database) {
     sessionStore: new SessionStore(db),
     plcDirectoryUrl: env.PLC_URL,
     handleResolver: env.PDS_URL,
+    allowHttp: env.ALLOW_HTTP,
   })
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv'
-import { cleanEnv, port, str, testOnly, url } from 'envalid'
+import { bool, cleanEnv, port, str, testOnly, url } from 'envalid'
 import { envalidJsonWebKeys as keys } from '#/lib/jwk'
 
 dotenv.config()
@@ -22,4 +22,5 @@ export const env = cleanEnv(process.env, {
   PDS_URL: url({ default: undefined }),
   PLC_URL: url({ default: undefined }),
   FIREHOSE_URL: url({ default: undefined }),
+  ALLOW_HTTP: bool({ default: false }),
 })

--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -69,6 +69,7 @@ function content({ statuses, didHandleMap, profile, myStatus }: Props) {
           : html`<div class="session-form">
               <div><a href="/login">Log in</a> to set your status!</div>
               <div>
+                <a href="/signup" class="button">Sign up</a>
                 <a href="/login" class="button">Log in</a>
               </div>
             </div>`}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -171,6 +171,7 @@ export const createRouter = (ctx: AppContext): RequestListener => {
         const service = env.PDS_URL ?? 'https://bsky.social'
         const url = await ctx.oauthClient.authorize(service, {
           scope: 'atproto transition:generic',
+          prompt: 'create',
         })
         res.redirect(url.toString())
       } catch (err) {


### PR DESCRIPTION
See the related [pull request on bluesky-social/atproto](https://github.com/bluesky-social/atproto/pull/4461) for the details of this parameter.

I've also added a `ALLOW_HTTP` environment variable to enable easier testing against the local dev-env for AT Protocol.

You can see a demo here: https://bsky.app/profile/thisismissem.social/post/3ma4setzr6s2t