### PR TITLE
Fix URL to tutorial in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An example application covering:
 - Listen to the network firehose for new data
 - Publish data on the user's account using a custom schema
 
-See https://atproto.com/guides/applications for a guide through the codebase.
+See https://atproto.com/guides/statusphere-tutorial for a guide through the codebase.
 
 This project uses [Next.js](https://nextjs.org) as a server framework and [Tap](https://github.com/bluesky-social/indigo/blob/main/cmd/tap/README.md) for syncing data from the Atmosphere.
 
@@ -24,4 +24,4 @@ pnpm dev
 # Navigate to http://127.0.0.1:3000
 ```
 
-To read data from the network, you'll need an instance of Tap running. Find instructions for getting set up by checking out the [Statusphere tutorial](https://atproto.com/guides/applications) or the [Tap repository](https://github.com/bluesky-social/indigo/blob/main/cmd/tap/README.md).
+To read data from the network, you'll need an instance of Tap running. Find instructions for getting set up by checking out the [Statusphere tutorial](https://atproto.com/guides/statusphere-tutorial) or the [Tap repository](https://github.com/bluesky-social/indigo/blob/main/cmd/tap/README.md).


### PR DESCRIPTION
Cool URIs don't change, but sometimes they do. Hence changing the links from https://atproto.com/guides/applications to https://atproto.com/guides/statusphere-tutorial in the README.