### PR TITLE
Provide admin password to Tap

### DIFF
--- a/lib/tap/index.ts
+++ b/lib/tap/index.ts
@@ -1,12 +1,13 @@
 import { Tap } from "@atproto/tap";
 
 const TAP_URL = process.env.TAP_URL || "http://localhost:2480";
+const TAP_ADMIN_PASSWORD = process.env.TAP_ADMIN_PASSWORD;
 
 let _tap: Tap | null = null;
 
 export const getTap = (): Tap => {
   if (!_tap) {
-    _tap = new Tap(TAP_URL);
+    _tap = new Tap(TAP_URL, { adminPassword: TAP_ADMIN_PASSWORD });
   }
   return _tap;
 };


### PR DESCRIPTION
Currently the app verifies that requests from Tap have the correct password, but the app doesn't provide this password in any requests to Tap. This makes the homepage hang whenever it needs to resolve the user's handle through Tap, if a password is set.