### PR TITLE
Generate lexicon types in dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "pnpm migrate && next dev",
+    "dev": "pnpm migrate && pnpm build:lex && next dev",
     "build:lex": "ts-lex build --importExt=\"\" --out=./lib/lexicons --override",
     "build": "pnpm build:lex && next build",
     "start": "pnpm migrate && next start --port ${PORT-3000}",


### PR DESCRIPTION
## Summary
- `pnpm dev` runs `pnpm migrate && next dev`, but never generates `lib/lexicons` — that only happens via `build:lex`, which is wired into `pnpm build`, not `pnpm dev`.
- On a fresh clone, this makes the first request to any route importing generated lexicon types (e.g. `app/api/status/route.ts`) fail with `Module not found: Can't resolve '@/lib/lexicons/xyz'`.
- Updated the `dev` script to run `pnpm build:lex` before starting `next dev`, matching what `build` already does.

## Test plan
- [x] Removed `lib/lexicons`, ran `pnpm dev` fresh, confirmed it regenerates the lexicon types and starts cleanly
- [x] Hit `/` and `/api/status` and confirmed no module-not-found errors (status route returns 401 for unauthenticated request instead of 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)