### PR TITLE
Fix race in insertStatus that dropped the current-status flag

### DIFF
--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -59,7 +59,7 @@ export async function getTopStatuses(limit = 10) {
 }
 
 export async function insertStatus(data: StatusTable) {
-  getDb()
+  await getDb()
     .transaction()
     .execute(async (tx) => {
       await tx
@@ -73,7 +73,7 @@ export async function insertStatus(data: StatusTable) {
           }),
         )
         .execute();
-      setCurrStatus(tx, data.authorDid);
+      await setCurrStatus(tx, data.authorDid);
     });
 }
 


### PR DESCRIPTION
## Summary
- `insertStatus()` in `lib/db/queries.ts` called `getDb().transaction().execute(...)` without awaiting or returning it, and the inner `setCurrStatus(tx, ...)` call inside the transaction wasn't awaited either.
- The HTTP response (and the transaction commit) could resolve before the `current`-flag update finished, so concurrent calls raced and clobbered each other's update — in practice, every status row for an account could end up with `current = 0`, breaking the `StatusPicker` highlight and anything relying on "current status."

## Test plan
- [x] Reproduced against a live account with ~340 historical status records resynced through Tap: before the fix, every row ended up with `current=0`.
- [x] After the fix, exactly one row per author is `current=1`, verified across a 67-account, 1200+ record concurrent resync.
- [x] `pnpm build` and `pnpm lint` pass.