### PR TITLE
Add docker-compose.yml for local Tap setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ next-env.d.ts
 *.db-wal
 *.db-shm
 /lib/lexicons
+
+# tap
+/.tap-data

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An example application covering:
 - Listen to the network firehose for new data
 - Publish data on the user's account using a custom schema
 
-See https://atproto.com/guides/applications for a guide through the codebase.
+See https://atproto.com/guides/statusphere-tutorial for a guide through the codebase.
 
 This project uses [Next.js](https://nextjs.org) as a server framework and [Tap](https://github.com/bluesky-social/indigo/blob/main/cmd/tap/README.md) for syncing data from the Atmosphere.
 
@@ -24,7 +24,7 @@ pnpm dev
 # Navigate to http://127.0.0.1:3000
 ```
 
-To read data from the network, you'll need an instance of Tap running. Quickest way locally:
+To read data from the network, you'll need an instance of Tap running. Find full setup instructions in the [Statusphere tutorial](https://atproto.com/guides/statusphere-tutorial). Quickest way locally:
 
 ```sh
 docker compose up -d

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ pnpm dev
 # Navigate to http://127.0.0.1:3000
 ```
 
-To read data from the network, you'll need an instance of Tap running. The easiest way locally is via Docker Compose:
+To read data from the network, you'll need an instance of Tap running. Quickest way locally:
 
 ```sh
 docker compose up -d
 ```
 
-This runs Tap with `TAP_SIGNAL_COLLECTION` set to `xyz.statusphere.status`, so it automatically discovers and syncs any account that has posted a status through this app (or a fork of it) — no manual repo registration needed. Tap's webhook is pointed at the Next.js dev server on the host (`host.docker.internal:3000`), and its data is persisted to `.tap-data/` between restarts.
+It watches the `xyz.statusphere.status` collection, so it'll pick up any account that's posted a status through this app without you registering repos by hand. Data persists in `.tap-data/` between restarts.
 
-See `docker-compose.yml` for the full config, or the [Tap repository](https://github.com/bluesky-social/indigo/blob/main/cmd/tap/README.md) for other setup options (e.g. running from source, `TAP_ADMIN_PASSWORD` for securing the webhook in shared environments).
+For other setups (running from source, securing the webhook with `TAP_ADMIN_PASSWORD`, etc.), see the [Tap repository](https://github.com/bluesky-social/indigo/blob/main/cmd/tap/README.md).

--- a/README.md
+++ b/README.md
@@ -24,4 +24,12 @@ pnpm dev
 # Navigate to http://127.0.0.1:3000
 ```
 
-To read data from the network, you'll need an instance of Tap running. Find instructions for getting set up by checking out the [Statusphere tutorial](https://atproto.com/guides/applications) or the [Tap repository](https://github.com/bluesky-social/indigo/blob/main/cmd/tap/README.md).
+To read data from the network, you'll need an instance of Tap running. The easiest way locally is via Docker Compose:
+
+```sh
+docker compose up -d
+```
+
+This runs Tap with `TAP_SIGNAL_COLLECTION` set to `xyz.statusphere.status`, so it automatically discovers and syncs any account that has posted a status through this app (or a fork of it) — no manual repo registration needed. Tap's webhook is pointed at the Next.js dev server on the host (`host.docker.internal:3000`), and its data is persisted to `.tap-data/` between restarts.
+
+See `docker-compose.yml` for the full config, or the [Tap repository](https://github.com/bluesky-social/indigo/blob/main/cmd/tap/README.md) for other setup options (e.g. running from source, `TAP_ADMIN_PASSWORD` for securing the webhook in shared environments).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  tap:
+    image: ghcr.io/bluesky-social/indigo/tap:latest
+    command: ["/tap", "run", "--no-replay"]
+    ports:
+      - "127.0.0.1:2480:2480"
+    volumes:
+      - ./.tap-data:/data
+    environment:
+      # Reaches the Next.js dev server running on the host from inside the container.
+      TAP_WEBHOOK_URL: ${TAP_WEBHOOK_URL:-http://host.docker.internal:3000/api/webhook}
+      # Auto-discovers any account with a record in this collection, so accounts
+      # don't need to be registered manually via /repos/add. Per Tap's docs, the
+      # same collection should be set as both the signal collection and the filter.
+      TAP_SIGNAL_COLLECTION: xyz.statusphere.status
+      TAP_COLLECTION_FILTERS: xyz.statusphere.status


### PR DESCRIPTION
## Summary
- The README pointed at Tap's own repo for setup instructions with no concrete config for this app, so getting local network data flowing required piecing together flags/env vars by hand.
- Adds a `docker-compose.yml` that runs Tap with `TAP_SIGNAL_COLLECTION=xyz.statusphere.status`, so it automatically discovers and syncs any account that has posted a status through this app (or a fork of it) — no manual `/repos/add` registration needed.
- Tap's webhook is pointed at the Next.js dev server on the host (`host.docker.internal:3000`), and its data is persisted to `.tap-data/` (gitignored) between restarts.
- Updates the README's Tap section accordingly.

## Test plan
- [x] `docker compose up -d` starts Tap, connects to the production firehose, and enumerates repos matching `xyz.statusphere.status` (175 accounts discovered on a fresh volume) without any manual `/repos/add` call.
- [x] Confirmed the webhook reaches the dev server (`/api/webhook`) and populates `account`/`status` tables end-to-end.